### PR TITLE
Fix retired AI-901 learning path links

### DIFF
--- a/docs/ai-901/overview.md
+++ b/docs/ai-901/overview.md
@@ -100,9 +100,9 @@ Most challenges cost $0 using Azure AI services free tiers and Foundry explorati
 | Learning Path | Focus |
 |---------------|-------|
 | [Get started with AI on Azure](https://learn.microsoft.com/en-us/training/paths/get-started-with-artificial-intelligence-on-azure/) | AI fundamentals and concepts |
-| [Introduction to Azure AI Foundry](https://learn.microsoft.com/en-us/training/paths/introduction-azure-ai-foundry/) | Foundry portal and capabilities |
+| [Introduction to Azure AI Foundry](https://learn.microsoft.com/en-us/training/paths/ai-concepts/) | Foundry portal and capabilities |
 | [Explore generative AI with Azure](https://learn.microsoft.com/en-us/training/paths/introduction-generative-ai/) | GenAI concepts and Azure OpenAI |
-| [Build AI apps with Azure AI Foundry](https://learn.microsoft.com/en-us/training/paths/build-ai-apps-azure-ai-foundry/) | Hands-on Foundry implementation |
+| [Build AI apps with Azure AI Foundry](https://learn.microsoft.com/en-us/training/paths/get-started-ai-apps-agents/) | Hands-on Foundry implementation |
 
 ## What changed from AI-901?
 

--- a/i18n/pt-br/docusaurus-plugin-content-docs/current/ai-901/overview.md
+++ b/i18n/pt-br/docusaurus-plugin-content-docs/current/ai-901/overview.md
@@ -100,9 +100,9 @@ Most challenges cost $0 using Azure AI services free tiers and Foundry explorati
 | Learning Path | Focus |
 |---------------|-------|
 | [Get started with AI on Azure](https://learn.microsoft.com/en-us/training/paths/get-started-with-artificial-intelligence-on-azure/) | AI fundamentals and concepts |
-| [Introduction to Azure AI Foundry](https://learn.microsoft.com/en-us/training/paths/introduction-azure-ai-foundry/) | Foundry portal and capabilities |
+| [Introduction to Azure AI Foundry](https://learn.microsoft.com/en-us/training/paths/ai-concepts/) | Foundry portal and capabilities |
 | [Explore generative AI with Azure](https://learn.microsoft.com/en-us/training/paths/introduction-generative-ai/) | GenAI concepts and Azure OpenAI |
-| [Build AI apps with Azure AI Foundry](https://learn.microsoft.com/en-us/training/paths/build-ai-apps-azure-ai-foundry/) | Hands-on Foundry implementation |
+| [Build AI apps with Azure AI Foundry](https://learn.microsoft.com/en-us/training/paths/get-started-ai-apps-agents/) | Hands-on Foundry implementation |
 
 ## What changed from AI-901?
 


### PR DESCRIPTION
This PR replaces two retired Microsoft Learn path URLs in the AI-901 overview pages (EN and PT-BR) with the current replacement paths reported in the incident.\n\n- Replaced introduction-azure-ai-foundry with ai-concepts\n- Replaced build-ai-apps-azure-ai-foundry with get-started-ai-apps-agents\n\nFiles updated:\n- docs/ai-901/overview.md\n- i18n/pt-br/docusaurus-plugin-content-docs/current/ai-901/overview.md